### PR TITLE
Name the mock functions

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -11,11 +11,18 @@ test('create mock proxy', () => {
 
   expect(jest.isMockFunction(mock.bar)).toBeTruthy();
   expect(jest.isMockFunction(mock.foo)).toBeTruthy();
+  expect(mock.bar.getMockName()).toEqual('mock.bar');
+  expect(mock.foo.getMockName()).toEqual('mock.foo');
 
   mock.foo();
   mock.bar('foo');
   expect(mock.foo).toHaveBeenCalledTimes(1);
   expect(mock.bar).toHaveBeenCalledWith('foo');
+});
+
+test('set mock name', () => {
+  const mock = createMockProxy<{ foo(): void }>('myMock');
+  expect(mock.foo.getMockName()).toEqual('myMock.foo');
 });
 
 test('mock proxy allows to set return values', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export const createMockProxy = <T>() => {
+export const createMockProxy = <T>(objectName = 'mock') => {
   const cache = new Map<any, jest.Mock>();
   const handler: ProxyHandler<object> = {
     get: (_, name) => {
@@ -7,7 +7,7 @@ export const createMockProxy = <T>() => {
       }
 
       if (!cache.has(name)) {
-        cache.set(name, jest.fn());
+        cache.set(name, jest.fn().mockName(`${objectName}.${String(name)}`));
       }
 
       return cache.get(name);


### PR DESCRIPTION
This will make the failure messages more helpful:

Before:
> Expected mock function "**jest.fn()**" to have been called, but it was not called.

After:
> Expected mock function "**myMock.foo**" to have been called, but it was not called.

Btw, thanks for this simple lib, great idea and very useful 👍
